### PR TITLE
Create emergency-orders-functionality

### DIFF
--- a/src/en/space-station-14/round-flow/proposals/emergency-orders-functionality
+++ b/src/en/space-station-14/round-flow/proposals/emergency-orders-functionality
@@ -1,0 +1,109 @@
+# Emergency Orders Functionality
+
+| Designers | Implemented | GitHub Links |
+|---|---|---|
+| GoGoRoboto | :x: No | TBD |
+
+## Overview
+The primary goal is to reintroduce HoS' Emergency Orders and give the item purpose in line with the other command members' exclusive round start items —
+<br>The item should be both useful for Nanotrasen personel and important to keep from antagonists.
+This is split into two sections; The orders will gain functionality for HoS to call in ERT, or similar support, (with restrictions) and antagonists will be able to have special interaction to call in a disaster (similar to the ninja) or otherwise gain a benefit.
+
+This doc was originally created right before the Emergency Orders were removed. The HoS now has a gun in its place. However, some heads already have multiple objectives items (or dogs, in the case of Ian), so I see no issue with reintroducing the Emergency Orders with unique gameplay functionality.
+
+## Background
+
+All head roles have one or more round start items which are specific to their role. Most share all of these properties:
+- Syndicate Traitors may be tasked to steal it.
+- The relevant department head and their department have associated utility with the item (Ex. The CMO's hypo increases healing efficiency, RD's hand teleporter can link supply lines, QM's digiboard can make on-the-spot purchases).
+- Big or small, these items provide an advantage or special interaction.
+- An antagonist gains a new ability or route for a chosen playstyle when aquiring it. There is counter-gameplay and a reason to keep it out of antag hands.
+
+The head of security's Emergency Orders had been a syndicate objective item, but lack any other functionality. This led the vast majority of HoS players to never interact with their emergency orders in a given round. It is unsurprising as there is nothing interesting to be done with it. Because of this, the Emergency Orders had been one of the easiest steal objectives, despite being guarded by most well armed crew member.
+<br><br>While roleplay incentivises HoS players to guard the orders, the opposite is true mechanically as it takes up inventory space, which would now be contested by the HoS' shotgun. Another way to describe the item is unfun. Perhaps lame. Definitely useless.
+
+These are issues with the Emergency Orders, which led to its current removal:
+- It lacks any utility and is unfun to actively guard (wastes inventory space).
+- The difficulty to steal this item does not match the immersive expectation.
+- Once stolen, an antagonist gains no gameplay abilities and, too, is just using inventory space.
+- For antagonists who opt to ignore stealing this objective, it may be unclear what an appropriate equivalent goal is.
+- Rules are the only incentive for the HoS to guard it. For a chaotic roleplay space game, this is silly.
+
+## Terms
+
+I am introducing a number of new terms for this proposal. These are:
+- Initial Timer. The randomized time it takes for the Emergency Orders to gain funtionality. This time is hidden. Attempting to interact before this hidden timer is up results in a message, "All local emergency teams teams are unavailable."
+- Support Option. Which order is being sent to Centcom. Different Support Options have different speso costs. These supports appear in nearby space.
+- EMAG Option. Payment from mysterious benefactors in exchange for exploiting confidential Nanotrasen intel. These have no additional costs and may only be claimed once per shift.
+
+## Station-Side Functionality
+
+On round start, the Emergency Orders will not have immediate functionality. Once the Initial Timer is complete, Support Options will be available once the Emergency Orders are placed into a Comms Console.
+
+For the Emergency Orders to gain functionality, all of the following conditions must be met:
+- The Emergency Orders are placed into a comms console.
+- The station's alert level is not Green.
+- The Initial Timer has passed. This timer is hidden, randomized, and based on the game mode (Ex. Survival has a shorter timer to open more ghost roles as people should be dying often, Nukies might have around an hour to incentivize some amount of haste.) Randomzing the timer with overlap reduces the chances of both command reliance of these orders and mode-based metagaming.
+- A chosen Support Option matches the gamemode and time elapsed (Large ERT teams might only 'make it' on very slow nukie rounds, while a cheap team would be more readily available)
+- The station can afford the chosen Support Option using security funds. Support Options have varried speso costs. A poor station may only be able to afford a few janitors. A wealthy, unimpeded station could afford more.
+- The station has not chosen any Support Option too recently. Higher-value options induce longer cooldowns. It should not be possible to call in more than a few low-impact options or one high-impact option in your average round.
+
+Some examples of Support Options:
+- Poor ERT. A small number of barely-armed ERT rejects. They even have a shuttle that is hard to control. Low speso cost.<br>"Sorry, but here at Centcom we reserve our best defenders for our best financial performers."
+- ERT Fireteam. A full fireteam of well-armed ERT members. High speso cost, high cooldown. Powerful options like this may have an additional timer (after the Inital Timer) before it can be called.
+- CBURN. Reserved for viral threats.
+- Jani ERT. For when the janitors are on strike after chem gave the clowns 42 buckets of lube.
+
+There is plenty of room for both combat and funny Support Options.
+
+## EMAG Functionality
+
+Once the Emergency Orders have been EMAG'd and subsequently placed into a comms console, EMAG functionality is enabled. EMAG Options are much simpler and have no additional costs. Once an EMAG Option is chosen, an announcement says "A communications console has been hijacked and an encrypted message has been sent to hostile entities."
+
+EMAG Options should not regularily put the station under threat of complete destruction. Also, these should be syndicate-themed. The effect should be slightly delayed so there is not announcement overlap. Here are some options:
+- A sleeper agent event occurs.
+- A syndicate disaster victim shuttle appears in space, but is forced to contain a number of syndicate agents (Traitors).
+- A number of free agents or minor antagonists randomly appear around the station.
+- A number of TC, as payment, appears at the comms console.
+- A number of genetic ancestor teleporters appear at the comms console.
+
+## Revolutionary Functionality
+
+Once a Head Revolutionary completes a special do-after interaction with the Emergency Orders and places it into a comms console, a duffel bag with trackers pointing to each station department head will appear at the comms console.
+
+Revolutionary rounds are not a favorite for many. This is a pseudo-bandaid function with the following goals:
+- Reduce stagnation in revolutionary rounds while heads hide in random lockers or on a shittle in space.
+- Give head revolutionaries a more streamlined way of achieving their goal.
+- Give command additional opportunites to spot revolutionaries as they go for a new high-value item.
+- Be a 'flavor-win'. Revolutionaries are syndicate sponsored and it feels beleivable that Nanotrasen secretly put a tracker inside department heads.
+
+## Things to Consider
+
+The time between a Support Option being chosen and its on-station effect is not immediate. Ghost roles will need to be populated (and by extension lottery'd).
+
+This is made with the future in mind. As new features, antagonists, and more are added, new Support Options and antagonist-specific functionality can be created.
+
+While no crew can directly and purposfully create ghost roles right now, the majority of antagonists have this ability. Either way, this change will only introduce a small number.
+
+The Emergency Orders steal objective should potentially be changed to "EMAG and relay the Emergency Orders at a Communications Console", or something.
+
+It is possible that this change will cause some players to 'play' for ERT in nukie rounds. Quickly saving up money in warops seems fine, but round stalling for ERT by hiding the nuke probably isnt. It is possible there should be an anti-stall change that accompanies this. However, if given an appropriate Initial Timer, I do not see this being much of an issue.
+
+With the introduction of the access breaker taking over some emag function, using and EMAG on the Emergency Orders and placing it on a comms console might be enough. Needing to both access break the comms console and EMAG the orders might be too high a cost.
+
+## Closing, Relating to Design Principles
+
+This new functionality is intented to be a semi-regular part of security, cargo, command, antagonist, and ghost-role gameplay.
+
+It should be costly and require coordination (both internally and with the called-in ghost roles) for the station to make effective use of this functionality. This means interaction between players. By the nature of Support Options costing spesos, the QM will have additional responsibility in keeping a rainy day fund — and the Captain should ensure this is done. Once a Support Option is called, the most relevant department head will be expected to coordinate with them. Due to the required conditions for the Emergency Orders to gain functionality, this change introduces far more roleplay interactions, responsibilities, and reactionary gameplay than meta actions. None of this is to say this change will force gameplay routes. ERT should be somewhat implactful but remain unrequired.
+
+It should take planning and potentially antag coordination for an antagonist to make any use of EMAG functionality (gaining access to the orders and a comms console in the first place). The effect will naturally induce chaos as the station becomes aware of the anouncement's implications, but the chaos would be no more than a ninja should typically be causing.
+
+These changes put the Head of Security's Emergency Orders in line with all of the other objective items when it comes to *existent* functionality. It also give HoS and sec a very good reason to protect the Emergency Orders. The item is given real weight.
+
+This proposal was inspired by Arcticular's forum post and accompanying replies
+<br>https://forum.spacestation14.com/t/hos-emergency-orders-ert-rework-proposal/9936/5
+
+Old version of this PR from last year where I didnt know how to fork it correctly (I hope I did it right this time):
+https://github.com/space-wizards/docs/pull/286
+Some feedback from cohanna taken into account


### PR DESCRIPTION
# Emergency Orders Functionality

| Designers | Implemented | GitHub Links |
|---|---|---|
| GoGoRoboto | :x: No | TBD |

## Overview
The primary goal is to reintroduce HoS' Emergency Orders and give the item purpose in line with the other command members' exclusive round start items —
<br>The item should be both useful for Nanotrasen personel and important to keep from antagonists.
This is split into two sections; The orders will gain functionality for HoS to call in ERT, or similar support, (with restrictions) and antagonists will be able to have special interaction to call in a disaster (similar to the ninja) or otherwise gain a benefit.

This doc was originally created right before the Emergency Orders were removed. The HoS now has a gun in its place. However, some heads already have multiple objectives items (or dogs, in the case of Ian), so I see no issue with reintroducing the Emergency Orders with unique gameplay functionality.

## Background

All head roles have one or more round start items which are specific to their role. Most share all of these properties:
- Syndicate Traitors may be tasked to steal it.
- The relevant department head and their department have associated utility with the item (Ex. The CMO's hypo increases healing efficiency, RD's hand teleporter can link supply lines, QM's digiboard can make on-the-spot purchases).
- Big or small, these items provide an advantage or special interaction.
- An antagonist gains a new ability or route for a chosen playstyle when aquiring it. There is counter-gameplay and a reason to keep it out of antag hands.

The head of security's Emergency Orders had been a syndicate objective item, but lack any other functionality. This led the vast majority of HoS players to never interact with their emergency orders in a given round. It is unsurprising as there is nothing interesting to be done with it. Because of this, the Emergency Orders had been one of the easiest steal objectives, despite being guarded by most well armed crew member.
<br><br>While roleplay incentivises HoS players to guard the orders, the opposite is true mechanically as it takes up inventory space, which would now be contested by the HoS' shotgun. Another way to describe the item is unfun. Perhaps lame. Definitely useless.

These are issues with the Emergency Orders, which led to its current removal:
- It lacks any utility and is unfun to actively guard (wastes inventory space).
- The difficulty to steal this item does not match the immersive expectation.
- Once stolen, an antagonist gains no gameplay abilities and, too, is just using inventory space.
- For antagonists who opt to ignore stealing this objective, it may be unclear what an appropriate equivalent goal is.
- Rules are the only incentive for the HoS to guard it. For a chaotic roleplay space game, this is silly.

## Terms

I am introducing a number of new terms for this proposal. These are:
- Initial Timer. The randomized time it takes for the Emergency Orders to gain funtionality. This time is hidden. Attempting to interact before this hidden timer is up results in a message, "All local emergency teams teams are unavailable."
- Support Option. Which order is being sent to Centcom. Different Support Options have different speso costs. These supports appear in nearby space.
- EMAG Option. Payment from mysterious benefactors in exchange for exploiting confidential Nanotrasen intel. These have no additional costs and may only be claimed once per shift.

## Station-Side Functionality

On round start, the Emergency Orders will not have immediate functionality. Once the Initial Timer is complete, Support Options will be available once the Emergency Orders are placed into a Comms Console.

For the Emergency Orders to gain functionality, all of the following conditions must be met:
- The Emergency Orders are placed into a comms console.
- The station's alert level is not Green.
- The Initial Timer has passed. This timer is hidden, randomized, and based on the game mode (Ex. Survival has a shorter timer to open more ghost roles as people should be dying often, Nukies might have around an hour to incentivize some amount of haste.) Randomzing the timer with overlap reduces the chances of both command reliance of these orders and mode-based metagaming.
- A chosen Support Option matches the gamemode and time elapsed (Large ERT teams might only 'make it' on very slow nukie rounds, while a cheap team would be more readily available)
- The station can afford the chosen Support Option using security funds. Support Options have varried speso costs. A poor station may only be able to afford a few janitors. A wealthy, unimpeded station could afford more.
- The station has not chosen any Support Option too recently. Higher-value options induce longer cooldowns. It should not be possible to call in more than a few low-impact options or one high-impact option in your average round.

Some examples of Support Options:
- Poor ERT. A small number of barely-armed ERT rejects. They even have a shuttle that is hard to control. Low speso cost.<br>"Sorry, but here at Centcom we reserve our best defenders for our best financial performers."
- ERT Fireteam. A full fireteam of well-armed ERT members. High speso cost, high cooldown. Powerful options like this may have an additional timer (after the Inital Timer) before it can be called.
- CBURN. Reserved for viral threats.
- Jani ERT. For when the janitors are on strike after chem gave the clowns 42 buckets of lube.

There is plenty of room for both combat and funny Support Options.

## EMAG Functionality

Once the Emergency Orders have been EMAG'd and subsequently placed into a comms console, EMAG functionality is enabled. EMAG Options are much simpler and have no additional costs. Once an EMAG Option is chosen, an announcement says "A communications console has been hijacked and an encrypted message has been sent to hostile entities."

EMAG Options should not regularily put the station under threat of complete destruction. Also, these should be syndicate-themed. The effect should be slightly delayed so there is not announcement overlap. Here are some options:
- A sleeper agent event occurs.
- A syndicate disaster victim shuttle appears in space, but is forced to contain a number of syndicate agents (Traitors).
- A number of free agents or minor antagonists randomly appear around the station.
- A number of TC, as payment, appears at the comms console.
- A number of genetic ancestor teleporters appear at the comms console.

## Revolutionary Functionality

Once a Head Revolutionary completes a special do-after interaction with the Emergency Orders and places it into a comms console, a duffel bag with trackers pointing to each station department head will appear at the comms console.

Revolutionary rounds are not a favorite for many. This is a pseudo-bandaid function with the following goals:
- Reduce stagnation in revolutionary rounds while heads hide in random lockers or on a shittle in space.
- Give head revolutionaries a more streamlined way of achieving their goal.
- Give command additional opportunites to spot revolutionaries as they go for a new high-value item.
- Be a 'flavor-win'. Revolutionaries are syndicate sponsored and it feels beleivable that Nanotrasen secretly put a tracker inside department heads.

## Things to Consider

The time between a Support Option being chosen and its on-station effect is not immediate. Ghost roles will need to be populated (and by extension lottery'd).

This is made with the future in mind. As new features, antagonists, and more are added, new Support Options and antagonist-specific functionality can be created.

While no crew can directly and purposfully create ghost roles right now, the majority of antagonists have this ability. Either way, this change will only introduce a small number.

The Emergency Orders steal objective should potentially be changed to "EMAG and relay the Emergency Orders at a Communications Console", or something.

It is possible that this change will cause some players to 'play' for ERT in nukie rounds. Quickly saving up money in warops seems fine, but round stalling for ERT by hiding the nuke probably isnt. It is possible there should be an anti-stall change that accompanies this. However, if given an appropriate Initial Timer, I do not see this being much of an issue.

With the introduction of the access breaker taking over some emag function, using and EMAG on the Emergency Orders and placing it on a comms console might be enough. Needing to both access break the comms console and EMAG the orders might be too high a cost.

## Closing, Relating to Design Principles

This new functionality is intented to be a semi-regular part of security, cargo, command, antagonist, and ghost-role gameplay.

It should be costly and require coordination (both internally and with the called-in ghost roles) for the station to make effective use of this functionality. This means interaction between players. By the nature of Support Options costing spesos, the QM will have additional responsibility in keeping a rainy day fund — and the Captain should ensure this is done. Once a Support Option is called, the most relevant department head will be expected to coordinate with them. Due to the required conditions for the Emergency Orders to gain functionality, this change introduces far more roleplay interactions, responsibilities, and reactionary gameplay than meta actions. None of this is to say this change will force gameplay routes. ERT should be somewhat implactful but remain unrequired.

It should take planning and potentially antag coordination for an antagonist to make any use of EMAG functionality (gaining access to the orders and a comms console in the first place). The effect will naturally induce chaos as the station becomes aware of the anouncement's implications, but the chaos would be no more than a ninja should typically be causing.

These changes put the Head of Security's Emergency Orders in line with all of the other objective items when it comes to *existent* functionality. It also give HoS and sec a very good reason to protect the Emergency Orders. The item is given real weight.

This proposal was inspired by Arcticular's forum post and accompanying replies
<br>https://forum.spacestation14.com/t/hos-emergency-orders-ert-rework-proposal/9936/5

Old version of this PR from last year where I didnt know how to fork it correctly (I hope I did it right this time):
https://github.com/space-wizards/docs/pull/286
Some feedback from cohanna taken into account